### PR TITLE
Mass of cleanups, error fixes, and convenience additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ __pycache__
 /include/*
 /lib/*
 /log/*
+.ropeproject
+*.pyc
+

--- a/bottly.py
+++ b/bottly.py
@@ -1,20 +1,18 @@
-# required modules
 import datetime
 import json
 import socket
 import re
 import time
 
-from urllib.request import urlopen
+from urllib import urlopen
 
+import utils
 import db as database
 from logger import log_setup, log
 
-# loading configurations from config.json
 with open("config.json") as json_data:
     data = json.load(json_data)
 
-# server/channel configs
 server = data["Server"]
 port = data["Port"]
 channels = data["Channel"]
@@ -23,16 +21,13 @@ nick = data["BotNick"]
 log_dir = data["LogDir"]
 log_file = data["LogFile"]
 
-# authenticated users/command trigger
 trusted = data["Trusted"]
 admins = data["Admins"]
 trigger = data["Trigger"]
 
-# responses for various commands
 response = data["Responses"]
 
-# only loaded when DEBUG is set to True in config.json
-if data["DEBUG"] in "True":
+if data["DEBUG"]:
     channels = ["#bottly"]
     nick = "bottly"
     trigger = "!"
@@ -41,7 +36,7 @@ if data["DEBUG"] in "True":
 
 
 class Bottly(object):
-    # initialize variables and database
+
     def __init__(self, server, port, nick, trusted, admins, trigger, response):
         self.server = server
         self.port = int(port)
@@ -58,7 +53,6 @@ class Bottly(object):
         self.db = database.connect()
         self.logger = log_setup(log_dir, log_file)
 
-    # functions for getting, maintaining and closing the connection
     def connect_server(self):
         self.irc = socket.socket()
         self.irc.connect((self.server, self.port))
@@ -87,7 +81,7 @@ class Bottly(object):
 
     def send_data(self, data):
         if data is not None:
-            data = self.unicode_to_bytes(data + "\r\n")
+            data = utils.unicode_to_bytes(data + "\r\n")
             self.irc.send(data)
 
     def get_data(self):
@@ -96,27 +90,28 @@ class Bottly(object):
         return data
 
     def analyze_data(self, data):
-        data = self.bytes_to_unicode(data)
+        data = utils.bytes_to_unicode(data)
         data = data.split()
-        if data[0] in "PING":
-            self.pong(data[1])
-        else:
-            user = self.get_user(data[0])
-            msg_type = data[1]
-            destination = data[2]
-            try:
-                message = data[3:]
-                message[0] = message[0][1:]
-                self.pretty_print(user, msg_type, destination, message)
-                if message[0][0] is self.trigger:
-                    command = message[0]
-                    message = message[1:]
-                else:
+        if len(data) > 1:
+            if data[0] in "PING":
+                self.pong(data[1])
+            else:
+                user = self.get_user(data[0])
+                msg_type = data[1]
+                destination = data[2]
+                try:
+                    message = data[3:]
+                    message[0] = message[0][1:]
+                    utils.pretty_print(user, msg_type, destination, message)
+                    if message[0][0] is self.trigger:
+                        command = message[0]
+                        message = message[1:]
+                    else:
+                        command = None
+                except IndexError:
                     command = None
-            except IndexError:
-                command = None
-                message = None
-            self.check_input(user, msg_type, destination, command, message)
+                    message = None
+                self.check_input(user, msg_type, destination, command, message)
 
     def check_input(self, user, msg_type, destination, command, message):
         if "ERROR" in msg_type:
@@ -126,20 +121,6 @@ class Bottly(object):
         elif msg_type in 'KICK':
             self.join_channel(destination)
 
-    # conversion functions
-    def bytes_to_unicode(self, data):
-        return data.decode("UTF-8")
-
-    def unicode_to_bytes(self, data):
-        return data.encode("UTF-8")
-
-    # makes data pretty terminal print/logger
-    def pretty_print(self, user, msg_type, destination, message):
-        if type(message) is list:
-            message = " ".join(message)
-        print("%s %s %s :%s" % (user, msg_type, destination, message))
-
-    # helper functions for command functions below
     def send_message(self, destination, data):
         message = "PRIVMSG %s :%s" % (destination, data)
         self.send_data(message)
@@ -163,11 +144,12 @@ class Bottly(object):
         self.send_message(destination, response["deny"])
 
     def trigger_check(self, data):
+        state = False
         if self.trigger in data:
+            state = True
             data = data.lstrip(self.trigger)
-            return True, data
+        return state, data
 
-    # command functions (in alphabetical order)
     def checkmail(self, destination, user):
         db = self.db
         all_rows = database.get_tells(db, user)
@@ -178,31 +160,26 @@ class Bottly(object):
                 self.send_message(destination, "%s, %s -%s" % (row[0], row[1], row[2]))
         if len(all_rows) > 4:
             return self.response["more_mail"]
-        elif not len(all_rows):
-            return self.response["no_mail"]
+        return self.response["no_mail"]
 
     def isup(self, url):
         resp = urlopen("http://www.isup.me/%s" % url).read()
         if re.search(str.encode("It's just you."), resp, re.DOTALL):
             return self.response["isup_up"]
-        else:
-            return self.response["isup_down"]
+        return self.response["isup_down"]
 
     def mail(self, destination, message, user):
-        db = self.db
-        database.save_tell(db, destination, message, user)
+        database.save_tell(self.db, destination, message, user)
 
     def autoTinyController(self, on):
         if on:
             return True, self.response["autotiny_off"]
-        else:
-            return False, self.response["autotiny_on"]
+        return False, self.response["autotiny_on"]
 
     def hushController(self, on):
         if on:
             return True, self.response["hush_on"]
-        else:
-            return False, self.response["hush_off"]
+        return False, self.response["hush_off"]
 
     def tinyurl(self, destination, url):
         try:
@@ -247,69 +224,66 @@ class Bottly(object):
         elif command == "admin":
             pass
 
-    # main logic of bot, decides what command to run if any
-    def command_filter(self, user, msg_type, destination, command, arg):
-        if command is not None:
-            trig_pass, command = self.trigger_check(command)
+    def admin_only_commands(self, command, destination, user, arg):
+        if "join" == command:
+            if len(arg) == 1:
+                self.join_channel(arg[0])
+        elif "leave" == command:
+            if len(arg) == 1:
+                self.leave_channel(arg[0])
+            else:
+                self.leave_channel(destination)
+        elif "quit" == command:
+            self.disconnect_server()
+
+    def trusted_commands(self, command, destination, user):
+        message = ""
+        if "hush" == command:
+            self.hushed, message = self.hushController(True)
+        elif "unhush" == command:
+            self.hushed, message = self.hushController(False)
+        elif "tinyoff" == command:
+            self.autotiny, message = self.autoTinyController(False)
+        elif "tinyon" == command:
+            self.autotiny, message = self.autoTinyController(True)
+        return self.autotiny, self.hushed, message
+
+    def user_commands(self, command, destination, user, arg):
+        message = ""
+        if "foo" == command:  # this is a test command
+            message = "bar"
+        elif "author" == command:
+            message = "kekler - http://github.com/kekler"
+        elif "checkmail" == command:
+            message = self.checkmail(destination, user)
+        elif command == "contributors":
+            message = "Dragonkeeper - Hosts on #nixheeads & bug fixes | darthlukan - bug fixes & db.py"
+        elif "help" == command:
+            if len(arg) == 1:
+                message = self.usage(arg[0])
+            else:
+                message = self.usage("user")
+        elif "isup" == command:
+            if len(arg) == 1:
+                message = self.isup(arg[0])
+            else:
+                message = self.usage("isup")
+        elif "mail" == command:
+            if len(arg) >= 2:
+                destination = arg[0]
+                mail = " ".join(arg[1:])
+                self.mail(destination, mail, user)
+            else:
+                message = self.usage("mail")
+        elif "uptime" == command:
+            message = self.uptime(self.start_time)
         else:
-            trig_pass = False
+            message = response["commandNotFound"]
 
-        if trig_pass:
-            log(self.logger, user, msg_type, destination, command, arg)
-            # admin only commands
-            if self.is_admin(destination, user):
-                if "join" == command:
-                    if len(arg) == 1:
-                        self.join_channel(arg[0])
-                elif "leave" == command:
-                    if len(arg) == 1:
-                        self.leave_channel(arg[0])
-                    else:
-                        self.leave_channel(destination)
-                elif "quit" == command:
-                    self.disconnect_server()
-            # trusted/admin only commands
-            if self.is_trusted(destination, user):
-                if "hush" == command:
-                    self.hushed, message = self.hushController(True)
-                elif "unhush" == command:
-                    self.hushed, message = self.hushController(False)
-                elif "tinyoff" == command:
-                    self.autotiny, message = self.autoTinyController(False)
-                elif "tinyon" == command:
-                    self.autotiny, message = self.autoTinyController(True)
-            # normal user/automatic commands
-            if not self.hushed:
-                if "foo" == command:  # this is a test command
-                    message = "bar"
-                elif "author" == command:
-                    message = "kekler - http://github.com/kekler"
-                elif "checkmail" == command:
-                    message = self.checkmail(destination, user)
-                elif command == "contributors":
-                    message = "Dragonkeeper - Hosts on #nixheeads & bug fixes | darthlukan - bug fixes & db.py"
-                elif "help" == command:
-                    if len(arg) == 1:
-                        message = self.usage(arg[0])
-                    else:
-                        message = self.usage("user")
-                elif "isup" == command:
-                    if len(arg) == 1:
-                        message = self.isup(arg[0])
-                    else:
-                        message = self.usage("isup")
-                elif "mail" == command:
-                    if len(arg) >= 2:
-                        destination = arg[0]
-                        mail = " ".join(arg[1:])
-                        self.mail(destination, mail, user)
-                    else:
-                        message = self.usage("mail")
-                elif "uptime" == command:
-                    message = self.uptime(self.start_time)
-                else:
-                    message = response["commandNotFound"] 
+        return message
 
+    def check_tiny(self, command, destination, user, arg):
+        message = ""
         if self.autotiny:
             print("self.autotiny")
             print("%s %s %s" % (user, command, arg))
@@ -320,31 +294,52 @@ class Bottly(object):
                 else:
                     message = self.usage("tiny")
             else:
-                if type(arg) is list:
+                if isinstance(arg, list):
                     for item in arg:
                         if "http" in item:
                             url = item
                             message = self.tinyurl(destination, url)
-                
-        elif not self.autotiny:
+        else:
             print("not self.autotiny")
             if "tiny" == command:
                 if len(arg) == 1:
                     url = arg[0]
-                    messsage = self.tinyurl(destination, url)
+                    message = self.tinyurl(destination, url)
                 else:
                     message = self.usage("tiny")
+        return message
+
+    def command_filter(self, user, msg_type, destination, command, arg):
+        if command is not None:
+            trig_pass, command = self.trigger_check(command)
+        else:
+            trig_pass = False
+
+        if trig_pass:
+            log(self.logger, user, msg_type, destination, command, arg)
+            if self.is_admin(destination, user):
+                self.admin_only_commands(command, destination, user, arg)
+
+            if self.is_trusted(destination, user):
+                self.autotiny, self.hushed, message = self.trusted_commands(command, destination, user)
+
+            if not self.hushed:
+                message = self.user_commands(command, destination, user, arg)
+
+        message = self.check_tiny(command, destination, user, arg)
 
         try:
-            self.pretty_print(self.nick, msg_type, destination, message)
+            utils.pretty_print(self.nick, msg_type, destination, message)
             if message is not None:
-                if type(message) is tuple:
+                if isinstance(message, tuple):
                     for line in message:
                         self.send_message(destination, line)
                 else:
                     self.send_message(destination, message)
         except UnboundLocalError:
             pass
+
+
 if __name__ == "__main__":
     bot = Bottly(server, port, nick, trusted, admins, trigger, response)
     bot.connect_server()

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "DEBUG": "False",
+    "DEBUG": false,
     "Admins": ["kekler"],
     "Trusted": [],
     "Server": "irc.freenode.net",

--- a/utils.py
+++ b/utils.py
@@ -6,7 +6,7 @@ def unicode_to_bytes(data):
     return data.encode("UTF-8")
 
 
-def pretty_print(self, user, msg_type, destination, message):
+def pretty_print(user, msg_type, destination, message):
     if isinstance(message, list):
         message = " ".join(message)
     print("%s %s %s :%s" % (user, msg_type, destination, message))

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,12 @@
+def bytes_to_unicode(data):
+        return data.decode("UTF-8")
+
+
+def unicode_to_bytes(data):
+    return data.encode("UTF-8")
+
+
+def pretty_print(self, user, msg_type, destination, message):
+    if isinstance(message, list):
+        message = " ".join(message)
+    print("%s %s %s :%s" % (user, msg_type, destination, message))


### PR DESCRIPTION
These commits fix some errors such as a few syntax errors and typos that directly contributed to missing responses from the bot, improper JSON, and the massive command filter method that was doing more than one thing.

There are a few new methods relevant to user permissions:

admin_only_commands
trusted_commands
user_commands

The utility functions that could have been static methods were split out from the Bottly object and placed in the utils.py module, since they are not specific to the bot and could be used elsewhere as the codebase grows.

There were a few places where type checking was relevant, I made those more pythonic by using "isinstance" as opposed to calling type() and then performing a check.

There were some PEP-8 violations that were minor, those are cleaned up (long lines, overly complex methods, etc).

There was also a strange import issue regarding urllib and the request class. The request class is either deprecated for completely removed in my Python 2.7.10 installation, so I removed that import and replaced it with just "from urllib import urlopen."  If your Python version throws an error, then it's trivial to revert the change. In any case, I'd recommend using the [requests library](http://docs.python-requests.org/en/latest/), it's compatible with Python2 and 3 and has several improvements as compared to urllib.